### PR TITLE
HEALTH-394 Sticker Layout (revisited)

### DIFF
--- a/bika/lims/browser/templates/stickers/Code_128_1x48mm.css
+++ b/bika/lims/browser/templates/stickers/Code_128_1x48mm.css
@@ -1,6 +1,6 @@
 .sticker {
     font-family: Helvetica, Arial;
-    font-size:6pt;
+    font-size:7pt;
     /* Total width: 46mm + 2x1mm = 48mm */
     padding:1mm; width: 46mm;
 }
@@ -12,10 +12,15 @@
 .sticker .sampling-date-info table {
     border-collapse:collapse;
     margin: 1px 1px 1px 1px;
-    font-size: 6pt;
     width:100%;
 }
 .sticker .analysisrequest-info table td,
 .sticker .sampling-date-info table td {
     border:none;
+}
+.barcode {
+    margin:0 auto;
+}
+.client-sample-id {
+    text-align:center;
 }

--- a/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
@@ -58,20 +58,7 @@
     <div class="analysisrequest-info">
         <table cellpadding="0" cellspacing="0" border="0">
             <tr>
-                <td class="sample-type" tal:content="sample_type"/>
-                <td class="preservation" tal:content="preservation"/>
-                <td class="sample-point" tal:content="sample_point"/>
-            </tr>
-        </table>
-    </div>
-
-    <!-- Sampling Date -->
-    <div class="sampling-date-info">
-        <table cellpadding="0" cellspacing="0" border="0">
-            <tr>
-                <td class='label' i18n:translate="">Sampling Date</td>
-                <td class='sampling-date' tal:content="sampling_date"></td>
-                <td class='sampler' tal:content="sampler"></td>
+                <td class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
             </tr>
         </table>
     </div>

--- a/bika/lims/browser/templates/stickers/Code_39_1x54mm.css
+++ b/bika/lims/browser/templates/stickers/Code_39_1x54mm.css
@@ -21,3 +21,6 @@
 .barcode {
     margin:0 auto;
 }
+.client-sample-id {
+    text-align:center;
+}

--- a/bika/lims/browser/templates/stickers/Code_39_1x54mm.css
+++ b/bika/lims/browser/templates/stickers/Code_39_1x54mm.css
@@ -1,6 +1,6 @@
 .sticker {
     font-family: Helvetica, Arial;
-    font-size:6pt;
+    font-size:7pt;
     /* Total width: 52mm + 2x1mm = 54mm */
     padding:1mm; width: 52mm;
 }
@@ -12,10 +12,12 @@
 .sticker .sampling-date-info table {
     border-collapse:collapse;
     margin: 1px 1px 1px 1px;
-    font-size: 6pt;
     width:100%;
 }
 .sticker .analysisrequest-info table td,
 .sticker .sampling-date-info table td {
     border:none;
+}
+.barcode {
+    margin:0 auto;
 }

--- a/bika/lims/browser/templates/stickers/Code_39_1x54mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_39_1x54mm.pt
@@ -58,20 +58,9 @@
     <div class="analysisrequest-info">
         <table cellpadding="0" cellspacing="0" border="0">
             <tr>
-                <td class="sample-type" tal:content="sample_type"/>
+                <td style="text-align:center;" class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
                 <td class="preservation" tal:content="preservation"/>
                 <td class="sample-point" tal:content="sample_point"/>
-            </tr>
-        </table>
-    </div>
-
-    <!-- Sampling Date -->
-    <div class="sampling-date-info">
-        <table cellpadding="0" cellspacing="0" border="0">
-            <tr>
-                <td class='label' i18n:translate="">Sampling Date</td>
-                <td class='sampling-date' tal:content="sampling_date"></td>
-                <td class='sampler' tal:content="sampler"></td>
             </tr>
         </table>
     </div>

--- a/bika/lims/browser/templates/stickers/Code_39_1x54mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_39_1x54mm.pt
@@ -58,9 +58,7 @@
     <div class="analysisrequest-info">
         <table cellpadding="0" cellspacing="0" border="0">
             <tr>
-                <td style="text-align:center;" class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
-                <td class="preservation" tal:content="preservation"/>
-                <td class="sample-point" tal:content="sample_point"/>
+                <td class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
             </tr>
         </table>
     </div>

--- a/bika/lims/browser/templates/stickers/Code_93_2dx38mm.css
+++ b/bika/lims/browser/templates/stickers/Code_93_2dx38mm.css
@@ -1,19 +1,35 @@
 .sticker {
     font-family: Helvetica, Arial;
-    font-size:6pt;
-    /* Total width: 3mm + 38mm + 3mm + 38mm + 3mm = 85mm*/
-    width: 85mm;
-    height:18mm;
-    max-height:18mm;
-    max-width:85mm;
+    font-size:7pt;
+    /* Total width: 1.5mm + 38mm + 1.5mm + 1.5mm + 38mm + 1.5mm = 82mm */
+    width: 82mm;
+    min-width:82mm;
+    max-width:82mm;
+    /* Total height: 1.5mm + 18mm + 1.5mm = 21mm */
+    height:21mm;
+    min-height:21mm;
+    max-height:21mm;
+
     overflow:hidden;
     border-bottom:none;
+    background-color:blue;
 }
 .sticker table.stickers-row {
     width:100%;
-    border-spacing: 10px;
     border-collapse: separate;
     background-color:#f5f5f5;
+}
+.sticker table.stickers-row td.sticker-vertical-separator {
+    height:1.5mm;
+    min-height:1.5mm;
+    max-height:1.5mm;
+    background-color:#dcdcdc;
+}
+.sticker table.stickers-row td.sticker-horizontal-separator {
+    width:1.5mm;
+    min-width:1.5mm;
+    max-width:1.5mm;
+    background-color:#dcdcdc;
 }
 .sticker table.stickers-row td.sticker-cell {
     background-color:#fff;
@@ -28,11 +44,17 @@
 .sticker .analysisrequest-info table,
 .sticker .sampling-date-info table {
     border-collapse:collapse;
-    font-size: 6pt;
     width:100%;
 }
 .sticker .analysisrequest-info table td,
 .sticker .sampling-date-info table td {
     border:none;
     padding-left:2mm;
+}
+
+.barcode {
+    margin:0 auto;
+}
+.client-sample-id {
+    text-align:center;
 }

--- a/bika/lims/browser/templates/stickers/Code_93_2dx38mm.css
+++ b/bika/lims/browser/templates/stickers/Code_93_2dx38mm.css
@@ -12,7 +12,6 @@
 
     overflow:hidden;
     border-bottom:none;
-    background-color:blue;
 }
 .sticker table.stickers-row {
     width:100%;

--- a/bika/lims/browser/templates/stickers/Code_93_2dx38mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_93_2dx38mm.pt
@@ -22,7 +22,16 @@
     items           python:[item1, item2];">
 <table cellpadding="0" cellspacing="0" class="stickers-row">
     <tr>
+        <td class="sticker-horizontal-separator"></td>
+        <td class="sticker-vertical-separator"></td>
+        <td class="sticker-horizontal-separator"></td>
+        <td class="sticker-horizontal-separator"></td>
+        <td class="sticker-vertical-separator"></td>
+        <td class="sticker-horizontal-separator"></td>
+    </tr>
+    <tr>
 <tal:sticker_loop repeat="item items">
+<td class="sticker-horizontal-separator"></td>
 <td class="sticker-cell">
 <tal:sticker define="
     ar                python:item[0];
@@ -58,10 +67,7 @@
     <div class="analysisrequest-info">
         <table cellpadding="0" cellspacing="0" border="0">
             <tr>
-                <td class="sample-type" tal:content="client_sample_id">
-                    <!--span tal:content="sample_type"></span><br/>
-                    <span tal:content="sampling_date"></span--->
-                </td>
+                <td class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
                 <td style="text-align:right;padding-right:2mm;">
                     <img tal:condition="hazardous | nothing"
                          tal:attributes="src string:${portal_url}/++resource++bika.lims.images/hazardous.png"/>
@@ -71,7 +77,16 @@
     </div>
 </tal:sticker>
 </td>
+<td class="sticker-horizontal-separator"></td>
 </tal:sticker_loop>
+</tr>
+<tr>
+    <td class="sticker-horizontal-separator"></td>
+    <td class="sticker-vertical-separator"></td>
+    <td class="sticker-horizontal-separator"></td>
+    <td class="sticker-horizontal-separator"></td>
+    <td class="sticker-vertical-separator"></td>
+    <td class="sticker-horizontal-separator"></td>
 </tr>
 </table>
 </tal:stickers>

--- a/bika/lims/browser/templates/stickers/Code_93_2x38mm.css
+++ b/bika/lims/browser/templates/stickers/Code_93_2x38mm.css
@@ -1,19 +1,34 @@
 .sticker {
     font-family: Helvetica, Arial;
-    font-size:6pt;
-    /* Total width: 3mm + 38mm + 3mm + 38mm + 3mm = 85mm*/
-    width: 85mm;
-    height:18mm;
-    max-height:18mm;
-    max-width:85mm;
+    font-size:7pt;
+    /* Total width: 1.5mm + 38mm + 1.5mm + 1.5mm + 38mm + 1.5mm = 82mm */
+    width: 82mm;
+    min-width:82mm;
+    max-width:82mm;
+    /* Total height: 1.5mm + 18mm + 1.5mm = 21mm */
+    height:21mm;
+    min-height:21mm;
+    max-height:21mm;
+
     overflow:hidden;
     border-bottom:none;
 }
 .sticker table.stickers-row {
     width:100%;
-    border-spacing: 10px;
     border-collapse: separate;
     background-color:#f5f5f5;
+}
+.sticker table.stickers-row td.sticker-vertical-separator {
+    height:1.5mm;
+    min-height:1.5mm;
+    max-height:1.5mm;
+    background-color:#dcdcdc;
+}
+.sticker table.stickers-row td.sticker-horizontal-separator {
+    width:1.5mm;
+    min-width:1.5mm;
+    max-width:1.5mm;
+    background-color:#dcdcdc;
 }
 .sticker table.stickers-row td.sticker-cell {
     background-color:#fff;
@@ -28,11 +43,17 @@
 .sticker .analysisrequest-info table,
 .sticker .sampling-date-info table {
     border-collapse:collapse;
-    font-size: 6pt;
     width:100%;
 }
 .sticker .analysisrequest-info table td,
 .sticker .sampling-date-info table td {
     border:none;
     padding-left:2mm;
+}
+
+.barcode {
+    margin:0 auto;
+}
+.client-sample-id {
+    text-align:center;
 }

--- a/bika/lims/browser/templates/stickers/Code_93_2x38mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_93_2x38mm.pt
@@ -22,7 +22,16 @@
     items           python:[item1, item2];">
 <table cellpadding="0" cellspacing="0" class="stickers-row">
     <tr>
+        <td class="sticker-horizontal-separator"></td>
+        <td class="sticker-vertical-separator"></td>
+        <td class="sticker-horizontal-separator"></td>
+        <td class="sticker-horizontal-separator"></td>
+        <td class="sticker-vertical-separator"></td>
+        <td class="sticker-horizontal-separator"></td>
+    </tr>
+    <tr>
 <tal:sticker_loop repeat="item items">
+<td class="sticker-horizontal-separator"></td>
 <td class="sticker-cell">
 <tal:sticker define="
     ar                python:item[0];
@@ -58,10 +67,7 @@
     <div class="analysisrequest-info">
         <table cellpadding="0" cellspacing="0" border="0">
             <tr>
-                <td class="sample-type" tal:content="client_sample_id">
-                    <!--span tal:content="sample_type"></span><br/>
-                    <span tal:content="sampling_date"></span--->
-                </td>
+                <td class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
                 <td style="text-align:right;padding-right:2mm;">
                     <img tal:condition="hazardous | nothing"
                          tal:attributes="src string:${portal_url}/++resource++bika.lims.images/hazardous.png"/>
@@ -71,7 +77,16 @@
     </div>
 </tal:sticker>
 </td>
+<td class="sticker-horizontal-separator"></td>
 </tal:sticker_loop>
+</tr>
+<tr>
+    <td class="sticker-horizontal-separator"></td>
+    <td class="sticker-vertical-separator"></td>
+    <td class="sticker-horizontal-separator"></td>
+    <td class="sticker-horizontal-separator"></td>
+    <td class="sticker-vertical-separator"></td>
+    <td class="sticker-horizontal-separator"></td>
 </tr>
 </table>
 </tal:stickers>


### PR DESCRIPTION
Apart from the [two new sticker layouts and 2 stickers per row](https://github.com/bikalabs/bika.lims/pull/1805) that was already available. This PR adds the following:

**Code 93 2x38mm sticker**
- Sampling Date removed.
- Sample Type replaced by Client Sample ID.
- Text centered and 6pt to 7pt.
- Fixed margins to 1.5mm

**Code 93 2dx38mm sticker modifs**
- Sampling Date removed.
- Sample Type replaced by Client Sample ID.
- Text centered and 6pt to 7pt.
- Fixed margins to 1.5mm

**Code 128 1x48mm sticker**
- Sampling Date removed.
- Sample Type replaced by Client Sample ID.
- Text centered and 6pt to 7pt.

**Code 39 1x54mm sticker**
- Sampling Date removed.
- Sample Type replaced by Client Sample ID.
- Text centered and 6pt to 7pt.

![health-394](https://cloud.githubusercontent.com/assets/832627/17139336/4f180c58-5344-11e6-9bc2-002836a520ea.png)
